### PR TITLE
Add support for file extension configuration

### DIFF
--- a/src/NetEscapades.Extensions.Logging.RollingFile/FileLoggerOptions.cs
+++ b/src/NetEscapades.Extensions.Logging.RollingFile/FileLoggerOptions.cs
@@ -11,6 +11,7 @@ namespace NetEscapades.Extensions.Logging.RollingFile
         private int? _fileSizeLimit = 10 * 1024 * 1024;
         private int? _retainedFileCountLimit = 2;
         private string _fileName = "logs-";
+        private string _extension = "txt";
         
 
         /// <summary>
@@ -63,6 +64,17 @@ namespace NetEscapades.Extensions.Logging.RollingFile
                 }
                 _fileName = value;
             }
+        }
+
+        /// <summary>
+        /// Gets or sets the filename extension to use for log files.
+        /// Defaults to <c>txt</c>.
+        /// Will strip any prefixed .
+        /// </summary>
+        public string Extension
+        {
+            get { return _extension; }
+            set { _extension = value?.TrimStart('.'); }
         }
 
         /// <summary>

--- a/src/NetEscapades.Extensions.Logging.RollingFile/FileLoggerProvider.cs
+++ b/src/NetEscapades.Extensions.Logging.RollingFile/FileLoggerProvider.cs
@@ -21,6 +21,7 @@ namespace NetEscapades.Extensions.Logging.RollingFile
     {
         private readonly string _path;
         private readonly string _fileName;
+        private readonly string _extension;
         private readonly int? _maxFileSize;
         private readonly int? _maxRetainedFiles;
 
@@ -33,6 +34,7 @@ namespace NetEscapades.Extensions.Logging.RollingFile
             var loggerOptions = options.CurrentValue;
             _path = loggerOptions.LogDirectory;
             _fileName = loggerOptions.FileName;
+            _extension = loggerOptions.Extension;
             _maxFileSize = loggerOptions.FileSizeLimit;
             _maxRetainedFiles = loggerOptions.RetainedFileCountLimit;
         }
@@ -65,7 +67,7 @@ namespace NetEscapades.Extensions.Logging.RollingFile
 
         private string GetFullName((int Year, int Month, int Day) group)
         {
-            return Path.Combine(_path, $"{_fileName}{group.Year:0000}{group.Month:00}{group.Day:00}.txt");
+            return Path.Combine(_path, $"{_fileName}{group.Year:0000}{group.Month:00}{group.Day:00}.{_extension}");
         }
 
         private (int Year, int Month, int Day) GetGrouping(LogMessage message)

--- a/test/NetEscapades.Extensions.Logging.RollingFile.Test/FileLoggerTests.cs
+++ b/test/NetEscapades.Extensions.Logging.RollingFile.Test/FileLoggerTests.cs
@@ -146,5 +146,65 @@ namespace NetEscapades.Extensions.Logging.RollingFile.Test
                 "Error message" + Environment.NewLine,
                 File.ReadAllText(Path.Combine(TempPath, "LogFile.20160504.txt")));
         }
+
+        [Fact]
+        public async Task CorrectlySetsFileExtensionWithDot()
+        {
+            var provider = new TestFileLoggerProvider(TempPath, extension: ".log");
+            var logger = (BatchingLogger)provider.CreateLogger("Cat");
+
+            await provider.IntervalControl.Pause;
+
+            logger.Log(_timestampOne, LogLevel.Information, 0, "Info message", null, (state, ex) => state);
+            logger.Log(_timestampOne.AddHours(1), LogLevel.Error, 0, "Error message", null, (state, ex) => state);
+
+            provider.IntervalControl.Resume();
+            await provider.IntervalControl.Pause;
+
+            Assert.Equal(
+                "2016-05-04 03:02:01.000 +00:00 [Information] Cat: Info message" + Environment.NewLine +
+                "2016-05-04 04:02:01.000 +00:00 [Error] Cat: Error message" + Environment.NewLine,
+                File.ReadAllText(Path.Combine(TempPath, "LogFile.20160504.log")));
+        }
+
+        [Fact]
+        public async Task CorrectlySetsFileExtensionWithoutDot()
+        {
+            var provider = new TestFileLoggerProvider(TempPath, extension: "log");
+            var logger = (BatchingLogger)provider.CreateLogger("Cat");
+
+            await provider.IntervalControl.Pause;
+
+            logger.Log(_timestampOne, LogLevel.Information, 0, "Info message", null, (state, ex) => state);
+            logger.Log(_timestampOne.AddHours(1), LogLevel.Error, 0, "Error message", null, (state, ex) => state);
+
+            provider.IntervalControl.Resume();
+            await provider.IntervalControl.Pause;
+
+            Assert.Equal(
+                "2016-05-04 03:02:01.000 +00:00 [Information] Cat: Info message" + Environment.NewLine +
+                "2016-05-04 04:02:01.000 +00:00 [Error] Cat: Error message" + Environment.NewLine,
+                File.ReadAllText(Path.Combine(TempPath, "LogFile.20160504.log")));
+        }
+
+        [Fact]
+        public async Task CorrectlyHandlesNullFileExtension()
+        {
+            var provider = new TestFileLoggerProvider(TempPath, extension: null);
+            var logger = (BatchingLogger)provider.CreateLogger("Cat");
+
+            await provider.IntervalControl.Pause;
+
+            logger.Log(_timestampOne, LogLevel.Information, 0, "Info message", null, (state, ex) => state);
+            logger.Log(_timestampOne.AddHours(1), LogLevel.Error, 0, "Error message", null, (state, ex) => state);
+
+            provider.IntervalControl.Resume();
+            await provider.IntervalControl.Pause;
+
+            Assert.Equal(
+                "2016-05-04 03:02:01.000 +00:00 [Information] Cat: Info message" + Environment.NewLine +
+                "2016-05-04 04:02:01.000 +00:00 [Error] Cat: Error message" + Environment.NewLine,
+                File.ReadAllText(Path.Combine(TempPath, "LogFile.20160504")));
+        }
     }
 }

--- a/test/NetEscapades.Extensions.Logging.RollingFile.Test/TestFileLoggerProvider.cs
+++ b/test/NetEscapades.Extensions.Logging.RollingFile.Test/TestFileLoggerProvider.cs
@@ -11,6 +11,7 @@ namespace NetEscapades.Extensions.Logging.RollingFile.Test
         public TestFileLoggerProvider(
             string path,
             string fileName = "LogFile.",
+            string extension = "txt",
             int maxFileSize = 32_000,
             int maxRetainedFiles = 100,
             bool includeScopes = false)
@@ -18,6 +19,7 @@ namespace NetEscapades.Extensions.Logging.RollingFile.Test
             {
                 LogDirectory = path,
                 FileName = fileName,
+                Extension = extension,
                 FileSizeLimit = maxFileSize,
                 RetainedFileCountLimit = maxRetainedFiles,
                 IsEnabled = true,


### PR DESCRIPTION
- Extension defaults to .txt to match existing functionality. 
- Extension option setting does no validation other than stripping leading '.' characters for ease of use.
- I've tried to match your formatting / style choices.
- The three tests are mere copies of the setup of the ```WritesToTextFile()``` test, but you appear to favour having all of the test setup code explicitly in the method, so I didn't refactor out the common code.

You are welcome to make any changes you see fit before merging, or of course I'm happy to discuss any changes you'd like me to make if you prefer.