### PR TITLE
New file when log is full

### DIFF
--- a/test/NetEscapades.Extensions.Logging.RollingFile.Test/FileLoggerTests.cs
+++ b/test/NetEscapades.Extensions.Logging.RollingFile.Test/FileLoggerTests.cs
@@ -51,7 +51,7 @@ namespace NetEscapades.Extensions.Logging.RollingFile.Test
             Assert.Equal(
                 "2016-05-04 03:02:01.000 +00:00 [Information] Cat: Info message" + Environment.NewLine +
                 "2016-05-04 04:02:01.000 +00:00 [Error] Cat: Error message" + Environment.NewLine,
-                File.ReadAllText(Path.Combine(TempPath, "LogFile.20160504.txt")));
+                File.ReadAllText(Path.Combine(TempPath, "LogFile.20160504.0.txt")));
         }
 
         [Fact]
@@ -70,11 +70,11 @@ namespace NetEscapades.Extensions.Logging.RollingFile.Test
 
             Assert.Equal(
                 "2016-05-04 03:02:01.000 +00:00 [Information] Cat: Info message" + Environment.NewLine,
-                File.ReadAllText(Path.Combine(TempPath, "LogFile.20160504.txt")));
+                File.ReadAllText(Path.Combine(TempPath, "LogFile.20160504.0.txt")));
 
             Assert.Equal(
                 "2016-05-05 03:02:01.000 +00:00 [Error] Cat: Error message" + Environment.NewLine,
-                File.ReadAllText(Path.Combine(TempPath, "LogFile.20160505.txt")));
+                File.ReadAllText(Path.Combine(TempPath, "LogFile.20160505.0.txt")));
         }
 
         [Fact]
@@ -108,11 +108,11 @@ namespace NetEscapades.Extensions.Logging.RollingFile.Test
 
             Assert.Equal(6, actualFiles.Length);
             Assert.Equal(new[] {
-                "LogFile.20160509.txt",
-                "LogFile.20160510.txt",
-                "LogFile.20160511.txt",
-                "LogFile.20160512.txt",
-                "LogFile.20160513.txt",
+                "LogFile.20160509.0.txt",
+                "LogFile.20160510.0.txt",
+                "LogFile.20160511.0.txt",
+                "LogFile.20160512.0.txt",
+                "LogFile.20160513.0.txt",
                 "randomFile.txt"
             }, actualFiles);
         }
@@ -144,7 +144,7 @@ namespace NetEscapades.Extensions.Logging.RollingFile.Test
                 "Info message" + Environment.NewLine +
                 "2016-05-04 04:02:01.000 +00:00 [Error] Cat:" + Environment.NewLine +
                 "Error message" + Environment.NewLine,
-                File.ReadAllText(Path.Combine(TempPath, "LogFile.20160504.txt")));
+                File.ReadAllText(Path.Combine(TempPath, "LogFile.20160504.0.txt")));
         }
 
         [Fact]
@@ -164,7 +164,7 @@ namespace NetEscapades.Extensions.Logging.RollingFile.Test
             Assert.Equal(
                 "2016-05-04 03:02:01.000 +00:00 [Information] Cat: Info message" + Environment.NewLine +
                 "2016-05-04 04:02:01.000 +00:00 [Error] Cat: Error message" + Environment.NewLine,
-                File.ReadAllText(Path.Combine(TempPath, "LogFile.20160504.log")));
+                File.ReadAllText(Path.Combine(TempPath, "LogFile.20160504.0.log")));
         }
 
         [Fact]
@@ -184,7 +184,7 @@ namespace NetEscapades.Extensions.Logging.RollingFile.Test
             Assert.Equal(
                 "2016-05-04 03:02:01.000 +00:00 [Information] Cat: Info message" + Environment.NewLine +
                 "2016-05-04 04:02:01.000 +00:00 [Error] Cat: Error message" + Environment.NewLine,
-                File.ReadAllText(Path.Combine(TempPath, "LogFile.20160504.log")));
+                File.ReadAllText(Path.Combine(TempPath, "LogFile.20160504.0.log")));
         }
 
         [Fact]
@@ -204,7 +204,7 @@ namespace NetEscapades.Extensions.Logging.RollingFile.Test
             Assert.Equal(
                 "2016-05-04 03:02:01.000 +00:00 [Information] Cat: Info message" + Environment.NewLine +
                 "2016-05-04 04:02:01.000 +00:00 [Error] Cat: Error message" + Environment.NewLine,
-                File.ReadAllText(Path.Combine(TempPath, "LogFile.20160504")));
+                File.ReadAllText(Path.Combine(TempPath, "LogFile.20160504.0")));
         }
     }
 }


### PR DESCRIPTION
Added behavior, so that a new file is created when the previous file is full. The files are separated by an additional counter, which is added between the current file format and the extension (e.g. `diagnostics-2019041111.0.log` instead of `diagnostics-2019041111.log`).