### PR TITLE
Fix multi-file logging feature

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -16,6 +16,7 @@
     <IsPackable>false</IsPackable>
     <NoPackageAnalysis>true</NoPackageAnalysis>
     <LangVersion>latest</LangVersion>
+    <CheckEolTargetFramework>false</CheckEolTargetFramework >
   </PropertyGroup>
 
   <Import Project="releasenotes.props" />

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -15,7 +15,7 @@
     <DebugType>embedded</DebugType>
     <IsPackable>false</IsPackable>
     <NoPackageAnalysis>true</NoPackageAnalysis>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <Import Project="releasenotes.props" />

--- a/src/NetEscapades.Extensions.Logging.RollingFile/FileLoggerOptions.cs
+++ b/src/NetEscapades.Extensions.Logging.RollingFile/FileLoggerOptions.cs
@@ -43,7 +43,7 @@ namespace NetEscapades.Extensions.Logging.RollingFile
             get { return _filesPerPeriodicityLimit; }
             set
             {
-                if (value <= 1)
+                if (value <= 0)
                 {
                     throw new ArgumentOutOfRangeException(nameof(value), $"{nameof(FilesPerPeriodicityLimit)} must be greater than 0.");
                 }

--- a/test/NetEscapades.Extensions.Logging.RollingFile.Test/FileLoggerTests.cs
+++ b/test/NetEscapades.Extensions.Logging.RollingFile.Test/FileLoggerTests.cs
@@ -158,7 +158,6 @@ namespace NetEscapades.Extensions.Logging.RollingFile.Test
                 .OrderBy(f => f)
                 .ToArray();
 
-            Assert.Equal(6, actualFiles.Length);
             Assert.Equal(expectedFilenames, actualFiles);
         }
 

--- a/test/NetEscapades.Extensions.Logging.RollingFile.Test/FileLoggerTests.cs
+++ b/test/NetEscapades.Extensions.Logging.RollingFile.Test/FileLoggerTests.cs
@@ -188,7 +188,7 @@ namespace NetEscapades.Extensions.Logging.RollingFile.Test
                 "Info message" + Environment.NewLine +
                 "2016-05-04 04:02:01.000 +00:00 [Error] Cat:" + Environment.NewLine +
                 "Error message" + Environment.NewLine,
-                File.ReadAllText(Path.Combine(TempPath, "LogFile.20160504.0.txt")));
+                File.ReadAllText(Path.Combine(TempPath, "LogFile.20160504.txt")));
         }
 
         [Fact]
@@ -208,7 +208,7 @@ namespace NetEscapades.Extensions.Logging.RollingFile.Test
             Assert.Equal(
                 "2016-05-04 03:02:01.000 +00:00 [Information] Cat: Info message" + Environment.NewLine +
                 "2016-05-04 04:02:01.000 +00:00 [Error] Cat: Error message" + Environment.NewLine,
-                File.ReadAllText(Path.Combine(TempPath, "LogFile.20160504.0.log")));
+                File.ReadAllText(Path.Combine(TempPath, "LogFile.20160504.log")));
         }
 
         [Fact]
@@ -228,7 +228,7 @@ namespace NetEscapades.Extensions.Logging.RollingFile.Test
             Assert.Equal(
                 "2016-05-04 03:02:01.000 +00:00 [Information] Cat: Info message" + Environment.NewLine +
                 "2016-05-04 04:02:01.000 +00:00 [Error] Cat: Error message" + Environment.NewLine,
-                File.ReadAllText(Path.Combine(TempPath, "LogFile.20160504.0.log")));
+                File.ReadAllText(Path.Combine(TempPath, "LogFile.20160504.log")));
         }
 
         [Fact]
@@ -248,7 +248,7 @@ namespace NetEscapades.Extensions.Logging.RollingFile.Test
             Assert.Equal(
                 "2016-05-04 03:02:01.000 +00:00 [Information] Cat: Info message" + Environment.NewLine +
                 "2016-05-04 04:02:01.000 +00:00 [Error] Cat: Error message" + Environment.NewLine,
-                File.ReadAllText(Path.Combine(TempPath, "LogFile.20160504.0")));
+                File.ReadAllText(Path.Combine(TempPath, "LogFile.20160504")));
         }
     }
 }


### PR DESCRIPTION
#17 introduced a new feature to roll files when they reach the maximum size. I put this behind a feature flag, but failed to test it properly 🙄 This implements a fix (and a few other minor bits)