### PR TITLE
Added support for multiple log-line formatters

### DIFF
--- a/.github/workflows/BuildAndPack.yml
+++ b/.github/workflows/BuildAndPack.yml
@@ -33,6 +33,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
+      - name: Setup dotnet
+        uses: actions/setup-dotnet@v2
+        with:
+          dotnet-version: | 
+            2.1.x
+            3.0.x
+            6.0.x
       - name: Cache .nuke/temp, ~/.nuget/packages
         uses: actions/cache@v2
         with:
@@ -54,6 +61,13 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v1
+      - name: Setup dotnet
+        uses: actions/setup-dotnet@v2
+        with:
+          dotnet-version: | 
+            2.1.x
+            3.0.x
+            6.0.x
       - name: Cache .nuke/temp, ~/.nuget/packages
         uses: actions/cache@v2
         with:
@@ -75,6 +89,13 @@ jobs:
     runs-on: macOS-latest
     steps:
       - uses: actions/checkout@v1
+      - name: Setup dotnet
+        uses: actions/setup-dotnet@v2
+        with:
+          dotnet-version: | 
+            2.1.x
+            3.0.x
+            6.0.x
       - name: Cache .nuke/temp, ~/.nuget/packages
         uses: actions/cache@v2
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [v2.5.0]
+
+* Add initial support for using custom log-line formats. Uses the same format as before by default. 
+* Added a Json Log Formatter for .NET Core 3.1+
+
 ## [v2.4.1]
 * 
 * Fix bug in file rolling behaviour (thanks @guillermo-ruffino)

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,7 +10,7 @@
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/andrewlock/NetEscapades.Extensions.Logging</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/andrewlock/NetEscapades.Extensions.Logging.RollingFile</RepositoryUrl><RepositoryType>git</RepositoryType>
+    <RepositoryUrl>https://github.com/andrewlock/NetEscapades.Extensions.Logging</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <DebugType>embedded</DebugType>
     <IsPackable>false</IsPackable>

--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RootNamespace></RootNamespace>
     <NoWarn>CS0649;CS0169</NoWarn>
     <NukeRootDirectory>..</NukeRootDirectory>

--- a/releasenotes.props
+++ b/releasenotes.props
@@ -1,11 +1,12 @@
 <Project>
   <PropertyGroup>
-    <PackageReleaseNotes Condition="'$(VersionPrefix)' == '2.4.1'">
+    <PackageReleaseNotes Condition="'$(VersionPrefix)' == '2.5.0'">
       <![CDATA[
 
 Features:
 
-* Fix bug in file rolling behaviour (thanks @guillermo-ruffino)
+* Add initial support for using custom log-line formats. Uses the same format as before by default.
+* Added a Json Log Formatter for .NET Core 3.1+
 
 ]]>
     </PackageReleaseNotes>

--- a/src/NetEscapades.Extensions.Logging.RollingFile/FileLoggerFactoryExtensions.cs
+++ b/src/NetEscapades.Extensions.Logging.RollingFile/FileLoggerFactoryExtensions.cs
@@ -20,6 +20,9 @@ namespace Microsoft.Extensions.Logging
         {
             builder.Services.AddSingleton<ILoggerProvider, FileLoggerProvider>();
             builder.Services.AddSingleton<ILogFormatter, SimpleLogFormatter>();
+#if NETCOREAPP3_0
+            builder.Services.AddSingleton<ILogFormatter, JsonLogFormatter>();
+#endif
             return builder;
         }
         

--- a/src/NetEscapades.Extensions.Logging.RollingFile/FileLoggerFactoryExtensions.cs
+++ b/src/NetEscapades.Extensions.Logging.RollingFile/FileLoggerFactoryExtensions.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Text;
 using Microsoft.Extensions.DependencyInjection;
 using NetEscapades.Extensions.Logging.RollingFile;
+using NetEscapades.Extensions.Logging.RollingFile.Formatters;
 
 namespace Microsoft.Extensions.Logging
 {
@@ -18,6 +19,7 @@ namespace Microsoft.Extensions.Logging
         public static ILoggingBuilder AddFile(this ILoggingBuilder builder)
         {
             builder.Services.AddSingleton<ILoggerProvider, FileLoggerProvider>();
+            builder.Services.AddSingleton<ILogFormatter, SimpleLogFormatter>();
             return builder;
         }
         

--- a/src/NetEscapades.Extensions.Logging.RollingFile/FileLoggerProvider.cs
+++ b/src/NetEscapades.Extensions.Logging.RollingFile/FileLoggerProvider.cs
@@ -11,6 +11,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using NetEscapades.Extensions.Logging.RollingFile.Formatters;
 using NetEscapades.Extensions.Logging.RollingFile.Internal;
 
 namespace NetEscapades.Extensions.Logging.RollingFile
@@ -30,10 +31,11 @@ namespace NetEscapades.Extensions.Logging.RollingFile
         private readonly PeriodicityOptions _periodicity;
 
         /// <summary>
-        /// Creates an instance of the <see cref="FileLoggerProvider" /> 
+        /// Creates an instance of the <see cref="FileLoggerProvider" />
         /// </summary>
         /// <param name="options">The options object controlling the logger</param>
-        public FileLoggerProvider(IOptionsMonitor<FileLoggerOptions> options) : base(options)
+        /// <param name="formatter"></param>
+        public FileLoggerProvider(IOptionsMonitor<FileLoggerOptions> options, IEnumerable<ILogFormatter> formatter) : base(options, formatter)
         {
             var loggerOptions = options.CurrentValue;
             _path = loggerOptions.LogDirectory;

--- a/src/NetEscapades.Extensions.Logging.RollingFile/Formatters/ILogFormatter.cs
+++ b/src/NetEscapades.Extensions.Logging.RollingFile/Formatters/ILogFormatter.cs
@@ -1,0 +1,25 @@
+﻿using System.Text;
+using Microsoft.Extensions.Logging;
+
+namespace NetEscapades.Extensions.Logging.RollingFile.Formatters
+{
+    /// <summary>
+    /// Formats log messages that are written to the log file
+    /// </summary>
+    public interface ILogFormatter
+    {
+        /// <summary>
+        /// Gets the name of the formatter
+        /// </summary>
+        string Name { get; }
+
+        /// <summary>
+        /// Writes the log message to the specified StringBuilder.
+        /// </summary>
+        /// <param name="logEntry">The log entry.</param>
+        /// <param name="scopeProvider">The provider of scope data.</param>
+        /// <param name="stringBuilder">The string builder for building the message to write to the log file.</param>
+        /// <typeparam name="TState">The type of the object to be written.</typeparam>
+        void Write<TState>(in LogEntry<TState> logEntry, IExternalScopeProvider scopeProvider, StringBuilder stringBuilder);
+    }
+}

--- a/src/NetEscapades.Extensions.Logging.RollingFile/Formatters/JsonLogFormatter.cs
+++ b/src/NetEscapades.Extensions.Logging.RollingFile/Formatters/JsonLogFormatter.cs
@@ -1,0 +1,254 @@
+﻿#if NETCOREAPP3_0
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+
+namespace NetEscapades.Extensions.Logging.RollingFile.Formatters
+{
+    public class JsonLogFormatter: ILogFormatter
+    {
+        private const string MessageTemplateKey = "{OriginalFormat}";
+
+        private static readonly JsonWriterOptions Options = new()
+        {
+            Indented = false,
+        };
+
+        public string Name => "json";
+
+        public void Write<TState>(in LogEntry<TState> logEntry, IExternalScopeProvider scopeProvider, StringBuilder stringBuilder)
+        {
+            var exception = logEntry.Exception;
+            var message = logEntry.Formatter(logEntry.State, exception);
+            using var stream = new MemoryStream();
+            using var writer = new Utf8JsonWriter(stream, Options);
+
+            writer.WriteStartObject();
+            writer.WriteString("Timestamp", logEntry.Timestamp);
+            writer.WriteString("Level", GetLogLevelString(logEntry.LogLevel));
+            writer.WriteString("Category", logEntry.Category);
+            writer.WriteString("Message", message);
+            if (exception != null)
+            {
+                var exceptionMessage = exception.ToString()
+                    .Replace(Environment.NewLine, " ");
+                writer.WriteString(nameof(Exception), exceptionMessage);
+            }
+
+            string messageTemplate = null;
+            if (logEntry.State != null)
+            {
+                writer.WriteStartObject(nameof(logEntry.State));
+                if (logEntry.State is IEnumerable<KeyValuePair<string, object>> stateProperties)
+                {
+                    foreach (KeyValuePair<string, object> item in stateProperties)
+                    {
+                        if (item.Key == MessageTemplateKey
+                            && item.Value is string template)
+                        {
+                            messageTemplate = template;
+                        }
+                        else
+                        {
+                            WriteItem(writer, item);
+                        }
+                    }
+                }
+                else
+                {
+                    writer.WriteString("Message", logEntry.State.ToString());
+                }
+                writer.WriteEndObject();
+            }
+
+            if (!string.IsNullOrEmpty(messageTemplate))
+            {
+                writer.WriteString("MessageTemplate", messageTemplate);
+            }
+
+            if (scopeProvider != null)
+            {
+                var writerWrapper = new WriterWrapper(writer);
+                scopeProvider.ForEachScope((scope, state) =>
+                {
+                    // Add dictionary scopes to the "root" object
+                    if (scope is IEnumerable<KeyValuePair<string, object>> scopeItems)
+                    {
+                        foreach (KeyValuePair<string, object> item in scopeItems)
+                        {
+                            WriteItem(state.Writer, item);
+                        }
+                    }
+                    else
+                    {
+                        state.Values.Add(scope); // add to list for inclusion in scope array
+                    }
+                }, writerWrapper);
+
+
+                if (writerWrapper.Values.Any())
+                {
+                    writer.WriteStartArray("Scopes");
+                    foreach (var value in writerWrapper.Values)
+                    {
+                        WriteValue(writer, value);
+                    }
+                    writer.WriteEndArray();
+                }
+            }
+
+            writer.WriteEndObject();
+            writer.Flush();
+
+            stringBuilder.AppendLine(Encoding.UTF8.GetString(stream.ToArray()));
+        }
+
+        private static string GetLogLevelString(LogLevel logLevel)
+        {
+            return logLevel switch
+            {
+                LogLevel.Trace => "Trace",
+                LogLevel.Debug => "Debug",
+                LogLevel.Information => "Information",
+                LogLevel.Warning => "Warning",
+                LogLevel.Error => "Error",
+                LogLevel.Critical => "Critical",
+                _ => throw new ArgumentOutOfRangeException(nameof(logLevel))
+            };
+        }
+
+        private void WriteItem(Utf8JsonWriter writer, KeyValuePair<string, object> item)
+        {
+            var key = item.Key;
+            switch (item.Value)
+            {
+                case bool boolValue:
+                    writer.WriteBoolean(key, boolValue);
+                    break;
+                case byte byteValue:
+                    writer.WriteNumber(key, byteValue);
+                    break;
+                case sbyte sbyteValue:
+                    writer.WriteNumber(key, sbyteValue);
+                    break;
+                case char charValue:
+#if NETCOREAPP
+                    writer.WriteString(key, MemoryMarshal.CreateSpan(ref charValue, 1));
+#else
+                    writer.WriteString(key, charValue.ToString());
+#endif
+                    break;
+                case decimal decimalValue:
+                    writer.WriteNumber(key, decimalValue);
+                    break;
+                case double doubleValue:
+                    writer.WriteNumber(key, doubleValue);
+                    break;
+                case float floatValue:
+                    writer.WriteNumber(key, floatValue);
+                    break;
+                case int intValue:
+                    writer.WriteNumber(key, intValue);
+                    break;
+                case uint uintValue:
+                    writer.WriteNumber(key, uintValue);
+                    break;
+                case long longValue:
+                    writer.WriteNumber(key, longValue);
+                    break;
+                case ulong ulongValue:
+                    writer.WriteNumber(key, ulongValue);
+                    break;
+                case short shortValue:
+                    writer.WriteNumber(key, shortValue);
+                    break;
+                case ushort ushortValue:
+                    writer.WriteNumber(key, ushortValue);
+                    break;
+                case null:
+                    writer.WriteNull(key);
+                    break;
+                default:
+                    writer.WriteString(key, ToInvariantString(item.Value));
+                    break;
+            }
+        }
+
+        private void WriteValue(Utf8JsonWriter writer, object item)
+        {
+            switch (item)
+            {
+                case bool boolValue:
+                    writer.WriteBooleanValue(boolValue);
+                    break;
+                case byte byteValue:
+                    writer.WriteNumberValue(byteValue);
+                    break;
+                case sbyte sbyteValue:
+                    writer.WriteNumberValue(sbyteValue);
+                    break;
+                case char charValue:
+#if NETCOREAPP
+                    writer.WriteStringValue(MemoryMarshal.CreateSpan(ref charValue, 1));
+#else
+                    writer.WriteStringValue(charValue.ToString());
+#endif
+                    break;
+                case decimal decimalValue:
+                    writer.WriteNumberValue(decimalValue);
+                    break;
+                case double doubleValue:
+                    writer.WriteNumberValue(doubleValue);
+                    break;
+                case float floatValue:
+                    writer.WriteNumberValue(floatValue);
+                    break;
+                case int intValue:
+                    writer.WriteNumberValue(intValue);
+                    break;
+                case uint uintValue:
+                    writer.WriteNumberValue(uintValue);
+                    break;
+                case long longValue:
+                    writer.WriteNumberValue(longValue);
+                    break;
+                case ulong ulongValue:
+                    writer.WriteNumberValue(ulongValue);
+                    break;
+                case short shortValue:
+                    writer.WriteNumberValue(shortValue);
+                    break;
+                case ushort ushortValue:
+                    writer.WriteNumberValue(ushortValue);
+                    break;
+                case null:
+                    writer.WriteNullValue();
+                    break;
+                default:
+                    writer.WriteStringValue(ToInvariantString(item));
+                    break;
+            }
+        }
+
+        private static string ToInvariantString(object obj) => Convert.ToString(obj, CultureInfo.InvariantCulture);
+
+        private readonly struct WriterWrapper
+        {
+            public readonly Utf8JsonWriter Writer;
+            public readonly List<object> Values;
+
+            public WriterWrapper(Utf8JsonWriter writer)
+            {
+                Writer = writer;
+                Values = new List<object>();
+            }
+        }
+    }
+}
+#endif

--- a/src/NetEscapades.Extensions.Logging.RollingFile/Formatters/LogEntry.cs
+++ b/src/NetEscapades.Extensions.Logging.RollingFile/Formatters/LogEntry.cs
@@ -1,0 +1,72 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// Based on https://github.com/dotnet/runtime/blob/6cb0e80fe6f4c13a8e7d3a1b43d8fe6ea9ffc344/src/libraries/Microsoft.Extensions.Logging.Abstractions/src/LogEntry.cs
+#nullable enable
+
+using System;
+using Microsoft.Extensions.Logging;
+
+namespace NetEscapades.Extensions.Logging.RollingFile.Formatters
+{
+    /// <summary>
+    /// Holds the information for a single log entry.
+    /// </summary>
+    public readonly struct LogEntry<TState>
+    {
+        /// <summary>
+        /// Initializes an instance of the LogEntry struct.
+        /// </summary>
+        /// <param name="timestamp">The time the event occured</param>
+        /// <param name="logLevel">The log level.</param>
+        /// <param name="category">The category name for the log.</param>
+        /// <param name="eventId">The log event Id.</param>
+        /// <param name="state">The state for which log is being written.</param>
+        /// <param name="exception">The log exception.</param>
+        /// <param name="formatter">The formatter.</param>
+        public LogEntry(DateTimeOffset timestamp, LogLevel logLevel, string category, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+        {
+            Timestamp = timestamp;
+            LogLevel = logLevel;
+            Category = category;
+            EventId = eventId;
+            State = state;
+            Exception = exception;
+            Formatter = formatter;
+        }
+
+        /// <summary>
+        /// Gets the time the event occured
+        /// </summary>
+        public DateTimeOffset Timestamp { get; }
+
+        /// <summary>
+        /// Gets the LogLevel
+        /// </summary>
+        public LogLevel LogLevel { get; }
+
+        /// <summary>
+        /// Gets the log category
+        /// </summary>
+        public string Category { get; }
+
+        /// <summary>
+        /// Gets the log EventId
+        /// </summary>
+        public EventId EventId { get; }
+
+        /// <summary>
+        /// Gets the TState
+        /// </summary>
+        public TState State { get; }
+
+        /// <summary>
+        /// Gets the log exception
+        /// </summary>
+        public Exception? Exception { get; }
+
+        /// <summary>
+        /// Gets the formatter
+        /// </summary>
+        public Func<TState, Exception?, string> Formatter { get; }
+    }
+}

--- a/src/NetEscapades.Extensions.Logging.RollingFile/Formatters/SimpleLogFormatter.cs
+++ b/src/NetEscapades.Extensions.Logging.RollingFile/Formatters/SimpleLogFormatter.cs
@@ -1,0 +1,44 @@
+﻿using System.Text;
+using Microsoft.Extensions.Logging;
+
+namespace NetEscapades.Extensions.Logging.RollingFile.Formatters
+{
+    /// <summary>
+    /// A simple formatter for log messages
+    /// </summary>
+    public class SimpleLogFormatter : ILogFormatter
+    {
+        public string Name => "simple";
+
+        /// <inheritdoc />
+        public void Write<TState>(in LogEntry<TState> logEntry, IExternalScopeProvider scopeProvider, StringBuilder builder)
+        {
+            builder.Append(logEntry.Timestamp.ToString("yyyy-MM-dd HH:mm:ss.fff zzz"));
+            builder.Append(" [");
+            builder.Append(logEntry.LogLevel.ToString());
+            builder.Append("] ");
+            builder.Append(logEntry.Category);
+
+            if (scopeProvider != null)
+            {
+                scopeProvider.ForEachScope((scope, stringBuilder) =>
+                {
+                    stringBuilder.Append(" => ").Append(scope);
+                }, builder);
+
+                builder.Append(':').AppendLine();
+            }
+            else
+            {
+                builder.Append(": ");
+            }
+
+            builder.AppendLine(logEntry.Formatter(logEntry.State, logEntry.Exception));
+
+            if (logEntry.Exception != null)
+            {
+                builder.AppendLine(logEntry.Exception.ToString());
+            }
+        }
+    }
+}

--- a/src/NetEscapades.Extensions.Logging.RollingFile/Internal/BatchingLoggerOptions.cs
+++ b/src/NetEscapades.Extensions.Logging.RollingFile/Internal/BatchingLoggerOptions.cs
@@ -73,5 +73,11 @@ namespace NetEscapades.Extensions.Logging.RollingFile.Internal
         /// Defaults to <c>false</c>.
         /// </summary>
         public bool IncludeScopes { get; set; } = false;
+
+        /// <summary>
+        /// Gets of sets the name of the log message formatter to use.
+        /// Defaults to "simple" />.
+        /// </summary>
+        public string FormatterName { get; set; } = "simple";
     }
 }

--- a/test/NetEscapades.Extensions.Logging.RollingFile.Test/TestFileLoggerProvider.cs
+++ b/test/NetEscapades.Extensions.Logging.RollingFile.Test/TestFileLoggerProvider.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Threading;
 using System.Threading.Tasks;
+using NetEscapades.Extensions.Logging.RollingFile.Formatters;
 
 namespace NetEscapades.Extensions.Logging.RollingFile.Test
 {
@@ -15,7 +16,8 @@ namespace NetEscapades.Extensions.Logging.RollingFile.Test
             int maxFileSize = 32_000,
             int maxRetainedFiles = 100,
             int maxFilesPerPeriodicity = 1,
-            bool includeScopes = false)
+            bool includeScopes = false,
+            ILogFormatter formatter = null)
             : base(new OptionsWrapperMonitor<FileLoggerOptions>(new FileLoggerOptions()
             {
                 LogDirectory = path,
@@ -25,8 +27,9 @@ namespace NetEscapades.Extensions.Logging.RollingFile.Test
                 RetainedFileCountLimit = maxRetainedFiles,
                 FilesPerPeriodicityLimit = maxFilesPerPeriodicity,
                 IsEnabled = true,
-                IncludeScopes = includeScopes
-            }))
+                IncludeScopes = includeScopes,
+                FormatterName = formatter?.Name ?? "simple"
+            }), new[] { formatter ?? new SimpleLogFormatter()})
         {
         }
 
@@ -35,5 +38,4 @@ namespace NetEscapades.Extensions.Logging.RollingFile.Test
             return IntervalControl.IntervalAsync();
         }
     }
-
 }

--- a/version.props
+++ b/version.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <VersionPrefix>2.4.1</VersionPrefix>
+    <VersionPrefix>2.5.0</VersionPrefix>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Created interface `ILogFormatter` that is used to format the log messages that are written to the file.
Currently includes a "simple" formatter, that uses the existing log line format.
The .NET Core 3.0+ target also includes a `JsonLogFormatter` that can write JSON log lines.
Select a formatter by setting `FormatterName` in the file options